### PR TITLE
Allow nginx to serve HTM/HTML files

### DIFF
--- a/apps/piwik/piwik.conf
+++ b/apps/piwik/piwik.conf
@@ -4,7 +4,7 @@
 location / {
 
     ## Disallow any usage of piwik assets if referer is non valid.
-    location ~* ^.+\.(?:css|gif|jpe?g|js|png|swf)$ {
+    location ~* ^.+\.(?:css|gif|html?|jpe?g|js|png|swf)$ {
         ## Defining the valid referers.
         valid_referers none blocked *.mysite.com othersite.com;
         if ($invalid_referer)  {
@@ -27,7 +27,7 @@ location / {
     }
 
     ## Disallow access to several helper files.
-    location ~* \.(?:bat|html?|git|ini|sh|svn[^.]*|txt|tpl|xml)$ {
+    location ~* \.(?:bat|git|ini|sh|svn[^.]*|txt|tpl|xml)$ {
         return 404;
     }
 


### PR DESCRIPTION
Since we now use AngularJS Piwik will sometimes fetch HTML templates via HTTP(s) so we need nginx to allow HTML files.

Suggested in http://forum.piwik.org/read.php?2,114386
