### PR TITLE
Remove configuration block "Disallow any usage of piwik assets if referer is non valid." as it breaks image icons in Piwik

### DIFF
--- a/apps/piwik/piwik.conf
+++ b/apps/piwik/piwik.conf
@@ -3,24 +3,6 @@
 ## Try all locations and relay to index.php as a fallback.
 location / {
 
-    ## Disallow any usage of piwik assets if referer is non valid.
-    location ~* ^.+\.(?:css|gif|html?|jpe?g|js|png|swf)$ {
-        ## Defining the valid referers.
-        valid_referers none blocked *.mysite.com othersite.com;
-        if ($invalid_referer)  {
-            return 444;
-        }
-        expires max;
-        ## No need to bleed constant updates. Send the all shebang in one
-        ## fell swoop.
-        tcp_nodelay off;
-        ## Set the OS file cache.
-        open_file_cache max=500 inactive=120s;
-        open_file_cache_valid 45s;
-        open_file_cache_min_uses 2;
-        open_file_cache_errors off;
-    }
-
     ## Do not serve HTML files from the /tmp folder.
     location ~* ^/tmp/.*\.html?$ {
         return 404;


### PR DESCRIPTION
fixes https://github.com/perusio/piwik-nginx/issues/34
This refs https://github.com/perusio/piwik-nginx/issues/35 (maybe fixes it?)

Also suggested this change in the Nginx.com wiki here: https://github.com/nginxinc/nginx-wiki/pull/376

As a security feature, this is not useful anyway.
