### PR TITLE
Comment out proxy_piwik_cache.conf inclusion by default

### DIFF
--- a/apps/piwik/piwik.conf
+++ b/apps/piwik/piwik.conf
@@ -41,7 +41,7 @@ location = /index.php {
     ## comment out the above.
     #proxy_pass http://phpapache;
     ### Use the proxy cache if proxying to Apache.
-    include apps/piwik/proxy_piwik_cache.conf;
+    #include apps/piwik/proxy_piwik_cache.conf;
 }
 
 ## Relay all piwik.php requests to fastcgi.


### PR DESCRIPTION
This include breaks the default setup due to duplicate `expires` statements in the config from both it and `fcgi_piwik_cache.conf`.  This block should remain commented unless proxying to Apache.