### PR TITLE
matomo doesn't work if the plugin directory is blocked

### DIFF
--- a/sites-available/matomo.conf
+++ b/sites-available/matomo.conf
@@ -74,7 +74,7 @@ server {
         add_header Cache-Control "public";
     }
 
-    location ~ /(libs|vendor|plugins|misc/user) {
+    location ~ /(libs|vendor|misc/user) {
         deny all;
         return 403;
     }


### PR DESCRIPTION
The following requests no longer work if the plugin directory is blocked:

- `/plugins/Morpheus/images/logo.svg?matomo`
- `/plugins/CoreHome/angularjs/notification/notification.directive.html`
- `/plugins/CoreHome/angularjs/quick-access/quick-access.directive.html`
- `/plugins/Morpheus/fonts/matomo.woff2`
- and many more...

I don't think it's possible to block the plugin directory.