### PR TITLE
Use prefix matching for disallow rule

### DIFF
--- a/sites-available/matomo.conf
+++ b/sites-available/matomo.conf
@@ -50,7 +50,7 @@ server {
     }
 
     ## disable all access to the following directories
-    location ~ /(config|tmp|core|lang) {
+    location ~ ^/(config|tmp|core|lang) {
         deny all;
         return 403; # replace with 404 to not show these directories exist
     }


### PR DESCRIPTION
The config|tmp|core|lang disallow rule used to match on every URL that contained one of the four keywords (e.g. `/plugins/LanguagesManager/angularjs/languageselector/languageselector.directive.js`).

This is not an issue with the current order of location blocks, but it can become an issue when reordering them.