### PR TITLE
Update matomo.conf

### DIFF
--- a/sites-available/matomo.conf
+++ b/sites-available/matomo.conf
@@ -33,7 +33,7 @@ server {
     ## only allow accessing the following php files
     location ~ ^/(index|matomo|piwik|js/index|plugins/HeatmapSessionRecording/configs)\.php {
         include snippets/fastcgi-php.conf; # if your Nginx setup doesn't come with a default fastcgi-php config, you can fetch it from https://github.com/nginx/nginx/blob/master/conf/fastcgi.conf
-        try_files $fastcgi_script_name =404; # protects against CVE-2019-11043. If this line is already included in your snippets/fastcgi-php.conf you can uncomment it here.
+        # try_files $fastcgi_script_name =404; # protects against CVE-2019-11043. If this line is not included in your snippets/fastcgi-php.conf you can uncomment it here.
         fastcgi_param HTTP_PROXY ""; # prohibit httpoxy: https://httpoxy.org/
         fastcgi_pass unix:/var/run/php/php7.2-fpm.sock; #replace with the path to your PHP socket file
         #fastcgi_pass 127.0.0.1:9000; # uncomment if you are using PHP via TCP sockets (e.g. Docker container)


### PR DESCRIPTION
1. By default this line is included in the fastcgi snippet
2. Current it talks about "uncommenting" a line which already doesn't have a comment