### PR TITLE
Use the correct referrer-policy to remove the referrer

### DIFF
--- a/sites-available/matomo.conf
+++ b/sites-available/matomo.conf
@@ -24,7 +24,7 @@ server {
 
     include ssl.conf; # if you want to support older browsers, please read through this file
 
-    add_header Referrer-Policy origin always; # make sure outgoing links don't show the URL to the Matomo instance
+    add_header Referrer-Policy same-origin; # make sure outgoing links don't show the URL to the Matomo instance
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
 


### PR DESCRIPTION
`same-origin` will send the full referrer information when following links within the Matomo instance, but nothing when following a link to another website.

https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-same-origin