### PR TITLE
Whitelist vendor HTML files

### DIFF
--- a/sites-available/matomo.conf
+++ b/sites-available/matomo.conf
@@ -81,6 +81,10 @@ server {
         deny all;
         return 403;
     }
+    
+    # Whitelist vendor html files
+    location ~ ^/vendor/.*\.html$ {
+    }
 
     ## properly display textfiles in root directory
     location ~/(.*\.md|LEGALNOTICE|LICENSE) {


### PR DESCRIPTION
Received this error on Matomo 4.5:

`Please check your server configuration. You may want to whitelist "*.html" files from the "plugins" directory. The HTTP status code is 403 for URL "plugins/CoreHome/angularjs/quick-access/quick-access.directive.html"`


