### PR TITLE
Remove json files from static file list to serve

### DIFF
--- a/sites-available/matomo.conf
+++ b/sites-available/matomo.conf
@@ -68,7 +68,7 @@ server {
         add_header Cache-Control 'private, no-cache, no-store';
     }
 
-    location ~ \.(gif|ico|jpg|png|svg|js|css|htm|html|mp3|mp4|wav|ogg|avi|ttf|eot|woff|woff2|json)$ {
+    location ~ \.(gif|ico|jpg|png|svg|js|css|htm|html|mp3|mp4|wav|ogg|avi|ttf|eot|woff|woff2)$ {
         allow all;
         ## Cache images,CSS,JS and webfonts for an hour
         ## Increasing the duration may improve the load-time, but may cause old files to show after an Matomo upgrade


### PR DESCRIPTION
I saw this issue https://github.com/matomo-org/matomo/issues/18128 that is solved in Matomo version 4.10.0. I guess JSON should be removed from the list of allowed static files in the Nginx config example as well.