### PR TITLE
Only permit defined paths

### DIFF
--- a/sites-available/matomo.conf
+++ b/sites-available/matomo.conf
@@ -1,3 +1,8 @@
+upstream _php {
+    server unix:/var/run/php/php8.2-fpm.sock; #replace with the path to your PHP socket file
+    #fastcgi_pass 127.0.0.1:9000; # uncomment if you are using PHP via TCP sockets (e.g. Docker container)
+}
+
 server {
     listen [::]:80; # remove this if you don't want Matomo to be reachable from IPv6
     listen 80;
@@ -24,6 +29,11 @@ server {
 
     include ssl.conf; # if you want to support older browsers, please read through this file
 
+    ## Only allow full site-access from trusted sources
+    # allow from 192.0.2.1;
+    # allow from 233.252.0.0/24;
+    # deny all;
+
     add_header Referrer-Policy origin always; # make sure outgoing links don't show the URL to the Matomo instance
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
@@ -32,59 +42,57 @@ server {
 
     index index.php;
 
-    ## only allow accessing the following php files
-    location ~ ^/(index|matomo|piwik|js/index|plugins/HeatmapSessionRecording/configs)\.php$ {
-        include snippets/fastcgi-php.conf; # if your Nginx setup doesn't come with a default fastcgi-php config, you can fetch it from https://github.com/nginx/nginx/blob/master/conf/fastcgi.conf
-        try_files $fastcgi_script_name =404; # protects against CVE-2019-11043. If this line is already included in your snippets/fastcgi-php.conf you can comment it here.
-        fastcgi_param HTTP_PROXY ""; # prohibit httpoxy: https://httpoxy.org/
-        fastcgi_pass unix:/var/run/php/php7.2-fpm.sock; #replace with the path to your PHP socket file
-        #fastcgi_pass 127.0.0.1:9000; # uncomment if you are using PHP via TCP sockets (e.g. Docker container)
-    }
-
-    ## deny access to all other .php files
-    location ~* ^.+\.php$ {
-        deny all;
-        return 403;
-    }
-
-    ## serve all other files normally
+    ## Deny everything that doesn't match another location
     location / {
-        try_files $uri $uri/ =404;
-    }
-
-    ## disable all access to the following directories
-    location ~ ^/(config|tmp|core|lang) {
         deny all;
-        return 403; # replace with 404 to not show these directories exist
+        return 404;
+    }
+    ## Need to allow GET / to internally redirect to /index.php
+    location = / { }
+
+    location = /robots.txt {}
+
+    ## Only allow public access to the following php files
+    location ~ ^/(matomo|piwik)\.php$ {
+        include snippets/fastcgi-php.conf;  # if your Nginx setup doesn't come with a default fastcgi-php config, you can fetch it from https://github.com/nginx/nginx/blob/master/conf/fastcgi.conf
+        fastcgi_param HTTP_PROXY ""; # prohibit httpoxy: https://httpoxy.org/
+        fastcgi_pass _php; # Refers to the upstream block above
+        allow all; # This ensures public access
     }
 
-    location ~ /\.ht {
-        deny  all;
-        return 403;
+    ## Only allow access to the following php files
+    location ~ ^/(index|js/index)\.php$ {
+        include snippets/fastcgi-php.conf;  # if your Nginx setup doesn't come with a default fastcgi-php config, you can fetch it from https://github.com/nginx/nginx/blob/master/conf/fastcgi.conf
+        fastcgi_param HTTP_PROXY ""; # prohibit httpoxy: https://httpoxy.org/
+        fastcgi_pass _php; # Refers to the upstream block above
     }
 
-    location ~ js/container_.*_preview\.js$ {
-        expires off;
-        add_header Cache-Control 'private, no-cache, no-store';
-    }
+    ## Uncomment bellow block(s) if needed
 
+    # location ~ ^/(plugins/HeatmapSessionRecording/configs)\.php$ {
+    #     include snippets/fastcgi-php.conf;  # if your Nginx setup doesn't come with a default fastcgi-php config, you can fetch it from https://github.com/nginx/nginx/blob/master/conf/fastcgi.conf
+    #     fastcgi_param HTTP_PROXY ""; # prohibit httpoxy: https://httpoxy.org/
+    #     fastcgi_pass _php; # Refers to the upstream block above
+    # }
+
+    # location ~ js/container_.*_preview\.js$ {
+    #     expires off;
+    #     add_header Cache-Control 'private, no-cache, no-store';
+    # }
+
+    ## Static files
     location ~ \.(gif|ico|jpg|png|svg|js|css|htm|html|mp3|mp4|wav|ogg|avi|ttf|eot|woff|woff2)$ {
-        allow all;
         ## Cache images,CSS,JS and webfonts for an hour
         ## Increasing the duration may improve the load-time, but may cause old files to show after an Matomo upgrade
         expires 1h;
         add_header Pragma public;
         add_header Cache-Control "public";
-    }
 
-    location ~ ^/(libs|vendor|plugins|misc|node_modules) {
-        deny all;
-        return 403;
-    }
+        # These are always public
+        location ~ ^/(matomo|piwik)\.js$ {
+            allow all;
+        }
 
-    ## properly display textfiles in root directory
-    location ~/(.*\.md|LEGALNOTICE|LICENSE) {
-        default_type text/plain;
     }
 }
 # vim: filetype=nginx


### PR DESCRIPTION
The current nginx config is permissive by default which makes it unsafe and bad practice.

For example the file `console` "php"-file is currently publicly accessible.
And future new/renamed files or paths will be accessible too that hasn't been included in the nginx config.

This PR revers this and instead denies everything except for the the defined paths.
These changes also makes it easy to restrict public access the full matomo site, by still allowing access to the paths needed to gather analytics (matomo.js, matomo.php, piwik.js & piwik.php).

As this is a slightly modified variant of what I have been tested, it may need some proofing.